### PR TITLE
Update sanctum.md - Improve example on Mobile Application Authentication

### DIFF
--- a/sanctum.md
+++ b/sanctum.md
@@ -396,12 +396,13 @@ Typically, you will make a request to the token endpoint from your mobile applic
         $user = User::where('email', $request->email)->first();
 
         if (! $user || ! Hash::check($request->password, $user->password)) {
-            throw ValidationException::withMessages([
-                'email' => ['The provided credentials are incorrect.'],
-            ]);
+            return response()->json([
+                'message' => 'Invalid credentials.',
+            ], 401);
         }
-
-        return $user->createToken($request->device_name)->plainTextToken;
+        return response()->json([
+            'token' => $user->createToken($request->device_name)->plainTextToken,
+        ]);
     });
 
 When the mobile application uses the token to make an API request to your application, it should pass the token in the `Authorization` header as a `Bearer` token.


### PR DESCRIPTION
Response of invalid auth is better to return JSON error message with more accurate HTTP code as ValidationException returns code 422 and a redirect to a HTML page with validation error bag, which isn't very friendly for an app to handle the error on their end.

Also returning token as a json response with 'token' key, more like the 'Issuing API Tokens' example on same page which is better standard for API responses instead of just a pure string result